### PR TITLE
unfurl optimizations

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -36,7 +36,7 @@ export const request = (config: IConfig, headers?: { [s: string]: any }): SuperA
 }
 
 export const run = async (req: SuperAgentRequest, config: IConfig):Promise<Response>  => {
-  const key = Math.random().toString(36).substr(2, 10)
+  const key = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
 
   try {
     const promise = req

--- a/src/unfurl.ts
+++ b/src/unfurl.ts
@@ -1,28 +1,38 @@
-import { get, merge } from 'lodash'
+import { get, merge, range, map } from 'lodash'
 
 import action, {IActionOpts, IResult} from './action'
 import {IConfig} from './config'
 
 export default async (appModel: string, actionName: string, opts: IActionOpts, config: IConfig): Promise<IResult> => {
+  const per = get(opts, 'params.per') || get(opts, 'body.per') || 100
+
   const result = await action(appModel, actionName, opts, config)
+  let objects = result.objects.slice()
 
   if (result.pagination) {
-    let currentPage = get(opts, 'params.page', 1)
+    const startPage = get(opts, 'params.page', 1)
 
-    while (currentPage < result.pagination.total_pages) {
-      currentPage += 1
+    if (startPage < result.pagination.total_pages) {
+      const pages = range(startPage+1, result.pagination.total_pages + 1)
+      const promises = map(pages, (page) => {
+        const pageOpts = merge({}, opts, { params: { page, per }, body: { page, per } })
 
-      const nextResults = await action(
-        appModel,
-        actionName,
-        merge({}, opts, { params: { page: currentPage } }),
-        config,
-      )
+        return action(
+          appModel,
+          actionName,
+          pageOpts,
+          config,
+        )
+      })
 
-      result.objects.push(...nextResults.objects)
+      const results = await Promise.all(promises)
+
+      for (let nextResult of results) {
+        objects.push(...nextResult.objects)
+      }
     }
-
     result.pagination.total_pages = 1
+    result.objects = objects
   }
 
   return result


### PR DESCRIPTION
1.
unfortunately most of our index endpoints support pagination and since
they're GET endpoints the page+per values must be transferred via url
params. however, we also do have POST (/search) endpoints that expect
the same page+per values to be part of the body. chipmunks 'action'
ignores the body when not applicable so it's safe to set it all the time
for params + body.

2.
run all the paginated requests in parallel to speedup things