### PR TITLE
fixes resolving associations after json schemas have been changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/association.ts
+++ b/src/association.ts
@@ -82,7 +82,11 @@ export const getSpecUrl = (prop: IProperty): string | null => {
     ["$jsonld_context", "$ref", "items.$jsonld_context", "items.$ref"],
     (x) => !!get(prop, x)
   );
-  return (path && (get(prop, path) as string)) || prop.type;
+  return (path && (get(prop, path) as string));
+};
+
+export const getSpecIdentifier = (prop: IProperty): string | null => {
+  return getSpecUrl(prop) || prop.type;
 };
 
 export const getId = (object) => {
@@ -157,7 +161,7 @@ export const fetch = async (
   }
 
   const associationProperty = objectSpec.associations[assocName];
-  const specUrl = getSpecUrl(associationProperty);
+  const specUrl = getSpecIdentifier(associationProperty);
   const associationSpec = await getSpec(specUrl, config);
 
   const extractedProps = extractProps(assocName, associationSpec, objects);

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -164,6 +164,9 @@ export const getSpec = async (
     spec.associations = reduce(
       spec.properties,
       (assocs, prop, name) => {
+        if (prop.anyOf && !prop['$jsonld_context']) {
+          prop = first(prop.anyOf);
+        }
         return getSpecUrl(prop) ? merge(assocs, { [name]: prop }) : assocs;
       },
       {}

--- a/tests/fixtures/bicycle.schema.ts
+++ b/tests/fixtures/bicycle.schema.ts
@@ -51,7 +51,10 @@ export default {
       },
     },
     manufacturer: {
-      $ref: "https://my.api.mediastore.dev/v2021/schemas/my.manufacturer.json",
+      anyOf: [
+        { $ref: "https://my.api.mediastore.dev/v2021/schemas/my.manufacturer.json" },
+        { type: "null" },
+      ]
     },
     wheels: {
       type: "array",


### PR DESCRIPTION
we've recently changed the schemas to define the type of properties to be
allowed to be either of the actual type, or to be null

this change fixes issues with chipmunk that wasn't able to properly parse
e.g.

``` location: {
 anyOf: [
   { '$ref': 'https://..' },
   { type: "null" }
 ]
}
```