### PR TITLE
Ensures params.per is always set if body.per is set to prevent duplicate/missing data

### DIFF
--- a/src/unfurl.ts
+++ b/src/unfurl.ts
@@ -14,9 +14,10 @@ export default async <T> (
 ): Promise<IResult<T>> => {
   const per = get(opts, "params.per") || get(opts, "body.per") || 100;
   
-  // Ensure params.per is always set for the initial request
+  // Ensure both params.per and body.per are always set for the initial request
   const initialOpts = merge({}, opts);
   initialOpts.params = { ...initialOpts.params, per };
+  initialOpts.body = { ...initialOpts.body, per };
 
   const result= await action<T>(appModel, actionName, initialOpts, config);
   let objects = result.objects.slice();

--- a/src/unfurl.ts
+++ b/src/unfurl.ts
@@ -14,12 +14,17 @@ export default async <T> (
 ): Promise<IResult<T>> => {
   const per = get(opts, "params.per") || get(opts, "body.per") || 100;
   
-  // Ensure both params.per and body.per are always set for the initial request
-  const initialOpts = merge({}, opts);
-  initialOpts.params = { ...initialOpts.params, per };
-  initialOpts.body = { ...initialOpts.body, per };
+  // modify opts for the action call if per was explicitly set in body or params
+  const explicitPer = get(opts, "params.per") || get(opts, "body.per");
+  const finalOpts = explicitPer !== undefined 
+    ? { 
+        ...opts, 
+        params: { ...opts.params, per: explicitPer },
+        body: { ...opts.body, per: explicitPer }
+      }
+    : opts;
 
-  const result= await action<T>(appModel, actionName, initialOpts, config);
+  const result = await action<T>(appModel, actionName, finalOpts, config);
   let objects = result.objects.slice();
 
   if (result.pagination) {

--- a/src/unfurl.ts
+++ b/src/unfurl.ts
@@ -18,7 +18,7 @@ export default async <T> (
   const initialOpts = merge({}, opts);
   initialOpts.params = { ...initialOpts.params, per };
 
-  const result= await action<T>(appModel, actionName, opts, config);
+  const result= await action<T>(appModel, actionName, initialOpts, config);
   let objects = result.objects.slice();
 
   if (result.pagination) {

--- a/src/unfurl.ts
+++ b/src/unfurl.ts
@@ -13,6 +13,10 @@ export default async <T> (
   config: IConfig
 ): Promise<IResult<T>> => {
   const per = get(opts, "params.per") || get(opts, "body.per") || 100;
+  
+  // Ensure params.per is always set for the initial request
+  const initialOpts = merge({}, opts);
+  initialOpts.params = { ...initialOpts.params, per };
 
   const result= await action<T>(appModel, actionName, opts, config);
   let objects = result.objects.slice();


### PR DESCRIPTION
The requests with undefined `params.per` but defined `body.per` return duplicate and missing data. 

The initial request returns a default of 100 items, but in the subsequent requests the `params.per`  is set to the value of `body.per`(usually set at  25)