### PR TITLE
Adds missing params for am calls that are part of an association;

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.5",
+  "version": "2.6.2-alpha.7",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2",
+  "version": "2.6.2-alpha.0",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.2",
+  "version": "2.6.2-alpha.3",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.3",
+  "version": "2.6.2-alpha.4",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.4",
+  "version": "2.6.2-alpha.5",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.1",
+  "version": "2.6.2-alpha.2",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.0",
+  "version": "2.6.2-alpha.1",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.7",
+  "version": "2.6.2-alpha.9",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "2.6.2-alpha.9",
+  "version": "2.6.3",
   "description": "helper library to talk to mediastore backends",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/action.ts
+++ b/src/action.ts
@@ -286,7 +286,8 @@ const performAction = async <T>(
 
   if (!opts.raw && !isEmpty(opts.schema)) {
     const schema = parseSchema(opts.schema);
-    objects = await resolve(objects, schema, config, opts.signal, opts.params);
+    const extraParams = opts.params?.include_folders != null ? { include_folders: opts.params.include_folders } : {};
+    objects = await resolve(objects, schema, config, opts.signal, extraParams);
   }
 
   const result: IResult<T> = {

--- a/src/action.ts
+++ b/src/action.ts
@@ -415,7 +415,7 @@ export default async <T>(
   }
 
   // Extract params that should be forwarded to associations
-  if ('include_folders' in (opts.params ?? {})) {
+  if ("include_folders" in (opts.params ?? {})) {
     opts._associationParams = { include_folders: opts.params.include_folders };
   }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -114,7 +114,7 @@ function checkAborted(signal?: AbortSignal, configSignal?: AbortSignal) {
   }
 }
 
-const resolve = async (objects, schema, config, signal?: AbortSignal) => {
+const resolve = async (objects, schema, config, signal?: AbortSignal, extraParams: { [s: string]: any } = {}) => {
   if (isEmpty(objects)) return [];
   if (schema === "*") return objects;
 
@@ -159,13 +159,13 @@ const resolve = async (objects, schema, config, signal?: AbortSignal) => {
       // Check if aborted before each association fetch
       checkAborted(signal, config.signal);
 
-      const result = await fetch(objects, assocName, config);
+      const result = await fetch(objects, assocName, config, extraParams);
 
       // first add props needed for the assignments later to the schema
       const neededProps = keys(result.extractedProps.allProps);
       reduce(neededProps, (acc, prop) => write(acc, { [prop]: true }), assocSchema)
 
-      const resolved = await resolve(result.objects, assocSchema, config, signal);
+      const resolved = await resolve(result.objects, assocSchema, config, signal, extraParams);
 
       // assign results to the target objects that were associating them
       await assign(objects, resolved, assocName, result.many, result.extractedProps);
@@ -286,10 +286,7 @@ const performAction = async <T>(
 
   if (!opts.raw && !isEmpty(opts.schema)) {
     const schema = parseSchema(opts.schema);
-    const resolveConfig = opts.params?.include_folders != null || opts.params?.include_folders != false
-      ? { ...config, defaultAssociationsParams: { ...config.defaultAssociationsParams, include_folders: opts.params.include_folders } }
-      : config;
-    objects = await resolve(objects, schema, resolveConfig, opts.signal);
+    objects = await resolve(objects, schema, config, opts.signal, opts.params);
   }
 
   const result: IResult<T> = {

--- a/src/action.ts
+++ b/src/action.ts
@@ -286,7 +286,7 @@ const performAction = async <T>(
 
   if (!opts.raw && !isEmpty(opts.schema)) {
     const schema = parseSchema(opts.schema);
-    const extraParams = opts.params?.include_folders != null ? { include_folders: opts.params.include_folders } : {};
+    const extraParams = 'include_folders' in (opts.params ?? {}) ? { include_folders: opts.params.include_folders } : {};
     objects = await resolve(objects, schema, config, opts.signal, extraParams);
   }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -286,7 +286,10 @@ const performAction = async <T>(
 
   if (!opts.raw && !isEmpty(opts.schema)) {
     const schema = parseSchema(opts.schema);
-    objects = await resolve(objects, schema, config, opts.signal);
+    const resolveConfig = opts.params?.include_folders != null || opts.params?.include_folders != false
+      ? { ...config, defaultAssociationsParams: { ...config.defaultAssociationsParams, include_folders: opts.params.include_folders } }
+      : config;
+    objects = await resolve(objects, schema, resolveConfig, opts.signal);
   }
 
   const result: IResult<T> = {

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,6 +7,7 @@ import uniq from "lodash/uniq";
 import flatten from "lodash/flatten";
 import omit from "lodash/omit";
 import pick from "lodash/pick";
+import pickBy from "lodash/pickBy";
 import keys from "lodash/keys";
 import reduce from "lodash/reduce";
 import filter from "lodash/filter";
@@ -43,6 +44,8 @@ export interface IActionOpts {
   schema?: string;
   signal?: AbortSignal;
   isFileDownload?: boolean;
+  // Internal: params to forward to association requests
+  _associationParams?: { [s: string]: any };
 }
 
 export interface IObject {
@@ -219,7 +222,34 @@ const performAction = async <T>(
   const axiosOptions: any = {
     signal: opts.signal || config.signal,
   };
-  if (config.timestamp) {
+  
+  // For GET requests, include non-template params as query parameters
+  if (action.method === "GET") {
+    // Extract all variable names from the URI template (e.g., {?ids,sort} or {id})
+    // This regex matches {var}, {?var}, {var1,var2}, {?var1,var2}, etc.
+    const templateVarMatches = action.template.match(/\{[^}]+\}/g) || [];
+    const templateVars = new Set<string>();
+    
+    templateVarMatches.forEach(match => {
+      // Remove braces and optional '?' prefix: "{?ids,sort}" -> "ids,sort"
+      const varString = match.replace(/[{}?]/g, '');
+      // Split by comma and add each variable: ["ids", "sort"]
+      varString.split(',').forEach(v => {
+        const cleanVar = v.split(':')[0].trim(); // Handle expressions like {var:3}
+        if (cleanVar) templateVars.add(cleanVar);
+      });
+    });
+    
+    // Only include params that are NOT template variables (those go in the URL)
+    const queryParams = pickBy(opts.params || {}, (_, key) => !templateVars.has(key));
+    if (Object.keys(queryParams).length > 0) {
+      axiosOptions.params = queryParams;
+    }
+    
+    if (config.timestamp) {
+      axiosOptions.params = { ...axiosOptions.params, t: config.timestamp };
+    }
+  } else if (config.timestamp) {
     axiosOptions.params = { t: config.timestamp };
   }
 
@@ -286,7 +316,7 @@ const performAction = async <T>(
 
   if (!opts.raw && !isEmpty(opts.schema)) {
     const schema = parseSchema(opts.schema);
-    const extraParams = 'include_folders' in (opts.params ?? {}) ? { include_folders: opts.params.include_folders } : {};
+    const extraParams = opts._associationParams || {};
     objects = await resolve(objects, schema, config, opts.signal, extraParams);
   }
 
@@ -382,6 +412,11 @@ export default async <T>(
 
   if (opts.proxy && isEmpty(opts.schema)) {
     throw new Error("Proxying is supported only if a schema is given, too.");
+  }
+
+  // Extract params that should be forwarded to associations
+  if ('include_folders' in (opts.params ?? {})) {
+    opts._associationParams = { include_folders: opts.params.include_folders };
   }
 
   return opts.proxy

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,7 +7,6 @@ import uniq from "lodash/uniq";
 import flatten from "lodash/flatten";
 import omit from "lodash/omit";
 import pick from "lodash/pick";
-import pickBy from "lodash/pickBy";
 import keys from "lodash/keys";
 import reduce from "lodash/reduce";
 import filter from "lodash/filter";
@@ -222,34 +221,8 @@ const performAction = async <T>(
   const axiosOptions: any = {
     signal: opts.signal || config.signal,
   };
-  
-  // For GET requests, include non-template params as query parameters
-  if (action.method === "GET") {
-    // Extract all variable names from the URI template (e.g., {?ids,sort} or {id})
-    // This regex matches {var}, {?var}, {var1,var2}, {?var1,var2}, etc.
-    const templateVarMatches = action.template.match(/\{[^}]+\}/g) || [];
-    const templateVars = new Set<string>();
-    
-    templateVarMatches.forEach(match => {
-      // Remove braces and optional '?' prefix: "{?ids,sort}" -> "ids,sort"
-      const varString = match.replace(/[{}?]/g, '');
-      // Split by comma and add each variable: ["ids", "sort"]
-      varString.split(',').forEach(v => {
-        const cleanVar = v.split(':')[0].trim(); // Handle expressions like {var:3}
-        if (cleanVar) templateVars.add(cleanVar);
-      });
-    });
-    
-    // Only include params that are NOT template variables (those go in the URL)
-    const queryParams = pickBy(opts.params || {}, (_, key) => !templateVars.has(key));
-    if (Object.keys(queryParams).length > 0) {
-      axiosOptions.params = queryParams;
-    }
-    
-    if (config.timestamp) {
-      axiosOptions.params = { ...axiosOptions.params, t: config.timestamp };
-    }
-  } else if (config.timestamp) {
+
+  if (config.timestamp) {
     axiosOptions.params = { t: config.timestamp };
   }
 

--- a/src/association.ts
+++ b/src/association.ts
@@ -212,6 +212,8 @@ export const fetch = async (
   }
 
   let result;
+  const extraParams = config.defaultAssociationsParams || {};
+
   if (performSearch) {
     const ids = [...extractedProps.allProps['id']];
     let associationSearch = {};
@@ -226,10 +228,10 @@ export const fetch = async (
       }
     }
 
-    result = await unfurl(specUrl, actionName, { params, body: mergeWith({ search: { filters: [['id', 'in', ids]] } }, associationSearch, customizer) }, config)
+    result = await unfurl(specUrl, actionName, { params: { ...params, ...extraParams }, body: mergeWith({ search: { filters: [['id', 'in', ids]] } }, associationSearch, customizer) }, config)
   }
   else {
-    result = await unfurl(specUrl, actionName, { params }, config);
+    result = await unfurl(specUrl, actionName, { params: { ...params, ...extraParams } }, config);
   }
 
   return {

--- a/src/association.ts
+++ b/src/association.ts
@@ -275,6 +275,18 @@ export const assignToJsonLd = (
     },
     {}
   );
+
+  // Fallback index by numeric id for cases where the JSON LD reference URL path
+  // differs from the object's canonical $id (e.g. /assets/1106981 vs /assets/folders/1106981)
+  const objectsByNumericId = reduce(
+    objects,
+    (acc, object) => {
+      if (object.id != null) return write(acc, { [toString(object.id)]: object });
+      return acc;
+    },
+    {}
+  );
+
   const targetsById = reduce(
     targets,
     (acc, target) => {
@@ -298,7 +310,7 @@ export const assignToJsonLd = (
       if (!isEmpty(matches))
         Object.defineProperty(target, assocName, { value: values(matches) });
     } else {
-      const match = objectsById[ref];
+      const match = objectsById[ref] || objectsByNumericId[(ref as string)?.split('/').pop()];
       if (!isEmpty(match))
         Object.defineProperty(target, assocName, { value: match });
     }

--- a/src/association.ts
+++ b/src/association.ts
@@ -146,7 +146,8 @@ const buildParams = (action: IAction, props) => {
 export const fetch = async (
   objects: any[],
   assocName: string,
-  { defaultAssociationsSearch , ...config }: IConfig = {}
+  { defaultAssociationsSearch , ...config }: IConfig = {},
+  extraParams: { [s: string]: any } = {}
 ): Promise<IFetchedResults> => {
   // since it might be possible the association we're looking for is only available for a subset of our objects
   // we first need to find the spec that contains a definition for the desired association..
@@ -212,7 +213,6 @@ export const fetch = async (
   }
 
   let result;
-  const extraParams = config.defaultAssociationsParams || {};
 
   if (performSearch) {
     const ids = [...extractedProps.allProps['id']];

--- a/src/association.ts
+++ b/src/association.ts
@@ -228,7 +228,19 @@ export const fetch = async (
       }
     }
 
-    result = await unfurl(specUrl, actionName, { params: { ...params, ...extraParams }, body: mergeWith({ search: { filters: [['id', 'in', ids]] } }, associationSearch, customizer) }, config)
+    result = await unfurl(
+      specUrl,
+      actionName,
+      {
+        params: { ...params, ...extraParams },
+        body: mergeWith(
+          { ...extraParams, search: { filters: [["id", "in", ids]] } },
+          associationSearch,
+          customizer
+        ),
+      },
+      config
+    )
   }
   else {
     result = await unfurl(specUrl, actionName, { params: { ...params, ...extraParams } }, config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,6 @@ export interface IConfig {
   watcher?: IWatcher;
   timestamp?: number;
   defaultAssociationsSearch?: { [s: string]: any };
-  defaultAssociationsParams?: { [s: string]: any };
   abortController?: AbortController;
   signal?: AbortSignal;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export interface IConfig {
   watcher?: IWatcher;
   timestamp?: number;
   defaultAssociationsSearch?: { [s: string]: any };
+  defaultAssociationsParams?: { [s: string]: any };
   abortController?: AbortController;
   signal?: AbortSignal;
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -874,4 +874,129 @@ describe("action", () => {
     const promise = chipmunk.action("um.user", "query");
     await expect(promise).to.be.rejectedWith(/unsupported URL/);
   });
+
+  it("passes include_folders param to association requests", async () => {
+    // Mock pm.product/asset context
+    nock(config.endpoints.pm)
+      .persist()
+      .get(matches("/context/product/asset"))
+      .reply(200, {
+        "@context": {
+          "@id": "https://pm.api.mediastore.dev/v20140601/context/product/asset",
+          properties: {
+            id: { readable: true, writable: false, exportable: true, type: "number" },
+            asset: { readable: true, writable: false, exportable: true, type: "https://am.api.mediastore.dev/v20140601/context/asset", collection: false }
+          },
+          collection_actions: {
+            query: {
+              method: "GET",
+              template: "https://pm.api.mediastore.dev/v20140601/products/assets{?include_folders}",
+              mappings: []
+            }
+          },
+          member_actions: {}
+        }
+      });
+
+    // Mock am.asset context
+    nock(config.endpoints.am)
+      .persist()
+      .get(matches("/context/asset"))
+      .reply(200, {
+        "@context": {
+          "@id": "https://am.api.mediastore.dev/v20140601/context/asset",
+          properties: {
+            id: { readable: true, writable: false, exportable: true, type: "number" },
+            name: { readable: true, writable: false, exportable: true, type: "string" }
+          },
+          collection_actions: {
+            get: {
+              method: "GET",
+              template: "https://am.api.mediastore.dev/v20140601/assets/{asset_ids}{?include_folders}",
+              mappings: [{ variable: "asset_ids", source: "id" }]
+            }
+          },
+          member_actions: {}
+        }
+      });
+
+    // Mock pm.product/asset query WITHOUT include_folders - return regular assets
+    nock(config.endpoints.pm)
+      .persist()
+      .get(matches("/products/assets"))
+      .query((q) => !q.include_folders)
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://pm.api.mediastore.dev/v20140601/context/product/asset",
+            "@id": "https://pm.api.mediastore.dev/v20140601/product/asset/1",
+            id: 1
+          }
+        ]
+      });
+
+    // Mock pm.product/asset query WITH include_folders - return assets including folders
+    nock(config.endpoints.pm)
+      .persist()
+      .get(matches("/products/assets"))
+      .query((q) => q.include_folders === "true")
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://pm.api.mediastore.dev/v20140601/context/product/asset",
+            "@id": "https://pm.api.mediastore.dev/v20140601/product/asset/1",
+            id: 1,
+            asset: {
+              "@id": "https://am.api.mediastore.dev/v20140601/asset/5"
+            }
+          }
+        ]
+      });
+
+    // Mock am.asset get WITHOUT include_folders - return non-folder assets
+    nock(config.endpoints.am)
+      .persist()
+      .get(matches("/assets"))
+      .query((q) => !q.include_folders)
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://am.api.mediastore.dev/v20140601/context/asset",
+            "@id": "https://am.api.mediastore.dev/v20140601/asset/5",
+            id: 5
+          }
+        ]
+      });
+
+    // Mock am.asset get WITH include_folders - return folder assets with data
+    nock(config.endpoints.am)
+      .persist()
+      .get(matches("/assets"))
+      .query((q) => q.include_folders === "true")
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://am.api.mediastore.dev/v20140601/context/asset",
+            "@id": "https://am.api.mediastore.dev/v20140601/asset/5",
+            id: 5,
+            name: "My Folder"
+          }
+        ]
+      });
+
+    await chipmunk.run(async (ch) => {
+      const result = await ch.action("pm.product/asset", "query", {
+        proxy: false,
+        params: { include_folders: true },
+        schema: "id, asset { name }"
+      });
+
+      expect(result.objects[0].asset).not.to.be.null;
+      expect(result.objects[0].asset.name).to.equal("My Folder");
+    });
+  });
 });

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -999,4 +999,106 @@ describe("action", () => {
       expect(result.objects[0].asset.name).to.equal("My Folder");
     });
   });
+
+  it("passes include_folders param to association search requests", async () => {
+    // Mock pm.product/asset context
+    nock(config.endpoints.pm)
+      .persist()
+      .get(matches("/context/product/asset"))
+      .reply(200, {
+        "@context": {
+          "@id": "https://pm.api.mediastore.dev/v20140601/context/product/asset",
+          properties: {
+            id: { readable: true, writable: false, exportable: true, type: "number" },
+            asset: { readable: true, writable: false, exportable: true, type: "https://am.api.mediastore.dev/v20140601/context/asset", collection: false }
+          },
+          collection_actions: {
+            query: {
+              method: "GET",
+              template: "https://pm.api.mediastore.dev/v20140601/products/assets{?product_ids,include_folders}",
+              mappings: [{ variable: "product_ids", source: "product_ids" }]
+            }
+          },
+          member_actions: {}
+        }
+      });
+
+    // Mock am.asset context with search action
+    nock(config.endpoints.am)
+      .persist()
+      .get(matches("/context/asset"))
+      .reply(200, {
+        "@context": {
+          "@id": "https://am.api.mediastore.dev/v20140601/context/asset",
+          properties: {
+            id: { readable: true, writable: false, exportable: true, type: "number" },
+            name: { readable: true, writable: false, exportable: true, type: "string" }
+          },
+          collection_actions: {
+            get: {
+              method: "GET",
+              template: "https://am.api.mediastore.dev/v20140601/asset/{id}",
+              mappings: [{ variable: "id", source: "id" }]
+            },
+            search: {
+              method: "POST",
+              template: "https://am.api.mediastore.dev/v20140601/assets/search",
+              mappings: []
+            }
+          },
+          member_actions: {}
+        }
+      });
+
+    // First request returns product assets with association references
+    nock(config.endpoints.pm)
+      .persist()
+      .get(matches("/products/assets"))
+      .query((q) => q.include_folders === "true")
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://pm.api.mediastore.dev/v20140601/context/product/asset",
+            "@id": "https://pm.api.mediastore.dev/v20140601/product/asset/1",
+            id: 1,
+            asset: {
+              "@id": "https://am.api.mediastore.dev/v20140601/asset/5"
+            }
+          }
+        ]
+      });
+
+    // Association search must receive include_folders in POST body
+    nock(config.endpoints.am)
+      .post(matches("/assets/search"), (body) => {
+        return (
+          body.include_folders === true &&
+          body.search?.filters?.[0]?.[0] === "id" &&
+          body.search?.filters?.[0]?.[1] === "in"
+        );
+      })
+      .reply(200, {
+        members: [
+          {
+            "@type": "asset",
+            "@context": "https://am.api.mediastore.dev/v20140601/context/asset",
+            "@id": "https://am.api.mediastore.dev/v20140601/asset/5",
+            id: 5,
+            name: "Search Asset"
+          }
+        ]
+      });
+
+    await chipmunk.run(async (ch) => {
+      const result = await ch.action("pm.product/asset", "query", {
+        proxy: false,
+        params: { product_ids: "753919", include_folders: true },
+        schema: "id, asset { id, name }"
+      });
+
+      expect(result.objects[0].asset).not.to.be.null;
+      expect(result.objects[0].asset.name).to.equal("Search Asset");
+    });
+  });
 });


### PR DESCRIPTION
In order for the BE to return the assets with type folder, `include_folders` param was introduced. For requests that were getting resolved by the association from 'pm.product/asset', `include_folders` param was not being passed to the AM call therefor no folders were included. 

- We added a new param called `_associationParams`, that if exists will be passed to all association calls. I adjust it to check only for  include_folder to avoid any side effects. 

- A fallback index by numeric id for cases where the JSON LD reference URL path differs from the object's canonical $id (e.g. /assets/1106981 vs /assets/folders/1106981)

